### PR TITLE
Bump log4j-core from 2.13.1 to 2.17.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 <dependency>
     <groupId>org.apache.logging.log4j</groupId>
     <artifactId>log4j-core</artifactId>
-    <version>2.13.1</version>
+    <version>2.17.1</version>
 </dependency>
 <!-- https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-api -->
 <dependency>


### PR DESCRIPTION
Bumps log4j-core from 2.13.1 to 2.17.1.

---
updated-dependencies:
- dependency-name: org.apache.logging.log4j:log4j-core dependency-type: direct:production ...